### PR TITLE
Modify sfadamw_v2 batch sizes

### DIFF
--- a/submissions/self_tuning/schedule_free_adamw_v2/submission.py
+++ b/submissions/self_tuning/schedule_free_adamw_v2/submission.py
@@ -234,13 +234,13 @@ def get_batch_size(workload_name):
   elif workload_name == 'fastmri':
     return 16
   elif workload_name == 'imagenet_resnet':
-    return 768
+    return 1024
   elif workload_name == 'imagenet_vit':
     return 1024
   elif workload_name == 'librispeech_conformer':
-    return 128
+    return 224
   elif workload_name == 'librispeech_deepspeech':
-    return 256
+    return 128
   elif workload_name == 'ogbg':
     return 512
   elif workload_name == 'wmt':


### PR DESCRIPTION
Set sfadamw to optimal batch sizes. With these batch sizes, all workloads hit the target within the updated time limits.

cc: @fsschneider 